### PR TITLE
fix URL of octav's lookup_user_by_auth_user_id method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ MYMETA.*
 /web-*
 
 tmp
+.idea

--- a/lib/WebService/Octav.pm
+++ b/lib/WebService/Octav.pm
@@ -1,5 +1,7 @@
 package WebService::Octav;
 use strict;
+use File::Basename ();
+use File::LibMagic;
 use JSON;
 use LWP::UserAgent;
 use URI;
@@ -39,8 +41,9 @@ sub create_user {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/user/create|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -72,7 +75,7 @@ sub lookup_user_by_auth_user_id {
             die qq|property "$required" must be provided|;
         }
     }
-    my $uri = URI->new($self->{endpoint} . qq|/v1/user/lookup_by_auth_user_id|);
+    my $uri = URI->new($self->{endpoint} . qq|/v1/user/lookup_user_by_auth_user_id|);
     $uri->query_form($payload);
     my $res = $self->{user_agent}->get($uri);
     if (!$res->is_success) {
@@ -90,8 +93,9 @@ sub update_user {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/user/update|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -107,8 +111,9 @@ sub delete_user {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/user/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -136,8 +141,9 @@ sub create_venue {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/venue/create|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -182,8 +188,9 @@ sub update_venue {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/venue/update|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -199,8 +206,9 @@ sub delete_venue {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/venue/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -216,8 +224,9 @@ sub create_room {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/room/create|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -233,8 +242,9 @@ sub update_room {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/room/update|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -267,8 +277,9 @@ sub delete_room {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/room/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -301,8 +312,9 @@ sub create_conference_series {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference_series/create|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -330,8 +342,9 @@ sub add_conference_series_admin {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference_series/admin/add|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -347,8 +360,9 @@ sub create_conference {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/create|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -364,8 +378,9 @@ sub add_conference_dates {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/dates/add|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -381,8 +396,9 @@ sub delete_conference_dates {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/dates/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -398,8 +414,9 @@ sub add_conference_admin {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/admin/add|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -415,8 +432,9 @@ sub delete_conference_admin {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/admin/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -432,8 +450,9 @@ sub add_conference_venue {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/venue/add|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -449,13 +468,97 @@ sub delete_conference_venue {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/venue/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
     }
     return 1
+}
+
+sub add_session_type {
+    my ($self, $payload) = @_;
+    for my $required (qw(user_id conference_id name abstract duration)) {
+        if (!$payload->{$required}) {
+            die qq|property "$required" must be provided|;
+        }
+    }
+    my $uri = URI->new($self->{endpoint} . qq|/v1/conference/session_type/add|);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
+    if (!$res->is_success) {
+        $self->{last_error} = $res->status_line;
+        return;
+    }
+    return 1
+}
+
+sub delete_session_type {
+    my ($self, $payload) = @_;
+    for my $required (qw(id user_id)) {
+        if (!$payload->{$required}) {
+            die qq|property "$required" must be provided|;
+        }
+    }
+    my $uri = URI->new($self->{endpoint} . qq|/v1/session_type/delete|);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
+    if (!$res->is_success) {
+        $self->{last_error} = $res->status_line;
+        return;
+    }
+    return 1
+}
+
+sub lookup_session_type {
+    my ($self, $payload) = @_;
+    for my $required (qw(id)) {
+        if (!$payload->{$required}) {
+            die qq|property "$required" must be provided|;
+        }
+    }
+    my $uri = URI->new($self->{endpoint} . qq|/v1/session_type/lookup|);
+    $uri->query_form($payload);
+    my $res = $self->{user_agent}->get($uri);
+    if (!$res->is_success) {
+        $self->{last_error} = $res->status_line;
+        return;
+    }
+    return JSON::decode_json($res->decoded_content);
+}
+
+sub update_session_type {
+    my ($self, $payload) = @_;
+    for my $required (qw(id user_id)) {
+        if (!$payload->{$required}) {
+            die qq|property "$required" must be provided|;
+        }
+    }
+    my $uri = URI->new($self->{endpoint} . qq|/v1/session_type/update|);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
+    if (!$res->is_success) {
+        $self->{last_error} = $res->status_line;
+        return;
+    }
+    return 1
+}
+
+sub list_session_types_by_conference {
+    my ($self, $payload) = @_;
+    my $uri = URI->new($self->{endpoint} . qq|/v1/session_type/list|);
+    $uri->query_form($payload);
+    my $res = $self->{user_agent}->get($uri);
+    if (!$res->is_success) {
+        $self->{last_error} = $res->status_line;
+        return;
+    }
+    return JSON::decode_json($res->decoded_content);
 }
 
 sub lookup_conference {
@@ -492,6 +595,18 @@ sub lookup_conference_by_slug {
     return JSON::decode_json($res->decoded_content);
 }
 
+sub list_conferences_by_organizer {
+    my ($self, $payload) = @_;
+    my $uri = URI->new($self->{endpoint} . qq|/v1/conference/list_by_organizer|);
+    $uri->query_form($payload);
+    my $res = $self->{user_agent}->get($uri);
+    if (!$res->is_success) {
+        $self->{last_error} = $res->status_line;
+        return;
+    }
+    return JSON::decode_json($res->decoded_content);
+}
+
 sub list_conference {
     my ($self, $payload) = @_;
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/list|);
@@ -512,8 +627,19 @@ sub update_conference {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/update|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    my @content;
+    my $magic = File::LibMagic->new();
+    for my $file (qw(cover)) {
+        if (my $fn = delete $payload->{$file}) {
+            my $info = $magic->info_from_filename($fn);
+            push @content, ($file => [$fn, File::Basename::basename($fn), Content_Type => $info->{mime_type}]);
+        }
+    }
+    push @content, (payload => JSON::encode_json($payload));
+    push @request_args, (Content_Type => "form-data");
+    push @request_args, (Content => \@content);
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -529,8 +655,9 @@ sub delete_conference_series {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference_series/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -546,8 +673,9 @@ sub delete_conference {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/conference/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -557,14 +685,15 @@ sub delete_conference {
 
 sub create_session {
     my ($self, $payload) = @_;
-    for my $required (qw(conference_id speaker_id title abstract duration user_id)) {
+    for my $required (qw(conference_id speaker_id title abstract session_type_id user_id)) {
         if (!$payload->{$required}) {
             die qq|property "$required" must be provided|;
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/session/create|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -597,8 +726,9 @@ sub delete_session {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/session/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -614,8 +744,9 @@ sub update_session {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/session/update|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -665,8 +796,9 @@ sub delete_question {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/question/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -716,8 +848,9 @@ sub add_featured_speaker {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/featured_speaker/add|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -762,8 +895,9 @@ sub update_featured_speaker {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/featured_speaker/update|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -779,8 +913,9 @@ sub delete_featured_speaker {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/featured_speaker/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -790,14 +925,15 @@ sub delete_featured_speaker {
 
 sub add_sponsor {
     my ($self, $payload) = @_;
-    for my $required (qw(conference_id logo_url1 name url group_name user_id)) {
+    for my $required (qw(conference_id name url group_name user_id)) {
         if (!$payload->{$required}) {
             die qq|property "$required" must be provided|;
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/sponsor/add|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -842,8 +978,19 @@ sub update_sponsor {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/sponsor/update|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    my @content;
+    my $magic = File::LibMagic->new();
+    for my $file (qw(logo1 logo2 logo3)) {
+        if (my $fn = delete $payload->{$file}) {
+            my $info = $magic->info_from_filename($fn);
+            push @content, ($file => [$fn, File::Basename::basename($fn), Content_Type => $info->{mime_type}]);
+        }
+    }
+    push @content, (payload => JSON::encode_json($payload));
+    push @request_args, (Content_Type => "form-data");
+    push @request_args, (Content => \@content);
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;
@@ -859,8 +1006,9 @@ sub delete_sponsor {
         }
     }
     my $uri = URI->new($self->{endpoint} . qq|/v1/sponsor/delete|);
-    my $json_payload = JSON::encode_json($payload);
-    my $res = $self->{user_agent}->post($uri, Content => $json_payload);
+    my @request_args;
+    push @request_args, (Content_Type => "application/json", Content => JSON::encode_json($payload));
+    my $res = $self->{user_agent}->post($uri, @request_args);
     if (!$res->is_success) {
         $self->{last_error} = $res->status_line;
         return;


### PR DESCRIPTION
Refs [octav PR #126](https://github.com/builderscon/octav/pull/126) - Fix lookup by auth_user_id

localでadminを走らせる方法をよくわかってないので動作確認していないのですが…。

[admin page](https://admin.builderscon.io/auth)からGitHubログインしようとするとログインできず何も起こらないという現象が起きていて、
![image](https://cloud.githubusercontent.com/assets/7414320/17645696/10a16ffc-61e8-11e6-9df9-94929bcca4e8.png)

[ログ](https://console.cloud.google.com/logs/viewer?project=builderscon-1248&minLogLevel=0&expandAll=false&resource=container.googleapis.com%2Fcluster_name%2Foctav-dev-cluster-1&logName=%2Fprojects%2Fbuilderscon-1248%2Flogs%2Fapiserver)を見たところ
- /v1/user/lookup_user_by_auth_user_id

ではなく
- /v1/user/lookup_by_auth_user_id

を呼び出しています。

![image](https://cloud.githubusercontent.com/assets/7414320/17645709/5f32bc84-61e8-11e6-9a29-4cb75fa252af.png)
