### PR TITLE
Place endif in the right place

### DIFF
--- a/templates/conference/view.html
+++ b/templates/conference/view.html
@@ -615,9 +615,7 @@
     <div id="external-resources-box" class="section scrollspy">
       <div id="external-resources" class="box">
         <div class="row box-header">
-          <div class="col s12">{% trans %}External Resources{% endtrans %}
-            <a href="#" id="add-external-resource-btn"><i class="material-icons vmiddle">library_add</i></a>
-          </div>
+          <div class="col s12">{% trans %}External Resources{% endtrans %}</div>
         </div>
         <div class="row">
           <div class="col s12">
@@ -640,9 +638,10 @@
           </div>
         </div>
 {% endfor %}
+{% endif %}
       </div>
     </div>
-{% endif %}
+
   </div>
 
   <div class="col hide-on-small-only m3 l2">


### PR DESCRIPTION
この現象の原因は閉じタグ&lt;/div&gt;忘れでした。
プロダクション環境のoctavにつないでbuilderscon 2016を表示して、問題が修正されていることを確認しました。
![pasted image at 2017_01_04 12_46 pm](https://cloud.githubusercontent.com/assets/7414320/21662436/fe56dce6-d31c-11e6-979a-42f6a6bc4016.png)

`<a href="#" id="add-external-resource-btn"><i class="material-icons vmiddle">library_add</i></a>
`
これを取り除いているのは、下の[+]のアイコンは必要ないからです。
<img width="264" alt="2017-01-05 8 05 21" src="https://cloud.githubusercontent.com/assets/7414320/21662576/bf7af466-d31d-11e6-802d-d4bf303203a2.png">


